### PR TITLE
feat(ics): add public series name and refresh

### DIFF
--- a/Pact Community Meeting.ics
+++ b/Pact Community Meeting.ics
@@ -1,6 +1,9 @@
 BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//ical.marudot.com//iCal Event Maker
+X-WR-CALNAME:Pact Community Meeting
+NAME:Pact Community Meeting
+REFRESH-INTERVAL;VALUE=DURATION:P1D
 CALSCALE:GREGORIAN
 BEGIN:VTIMEZONE
 TZID:Europe/London


### PR DESCRIPTION
As we are sharing the link publically, people can subscribe to the events in the calendar. This commit ensures that the series has a name, and hints to calendar client to refresh the invite once a day.